### PR TITLE
fix: ensure that encapsulated header is the last ICAP header

### DIFF
--- a/response.go
+++ b/response.go
@@ -119,7 +119,6 @@ func (w *respWriter) WriteHeader(code int, httpMessage interface{}, hasBody bool
 		}
 	}
 
-	w.header.Set("Encapsulated", encap)
 	if _, ok := w.header["Date"]; !ok {
 		w.Header().Set("Date", time.Now().UTC().Format(http.TimeFormat))
 	}
@@ -133,6 +132,12 @@ func (w *respWriter) WriteHeader(code int, httpMessage interface{}, hasBody bool
 	}
 	fmt.Fprintf(bw, "ICAP/1.0 %d %s\r\n", code, status)
 	w.header.Write(bw)
+
+	// ensure that Encapsulated header is the last one
+	h := http.Header{}
+	h.Set("Encapsulated", encap)
+	h.Write(bw)
+
 	io.WriteString(bw, "\r\n")
 
 	if header != nil {

--- a/response_test.go
+++ b/response_test.go
@@ -34,9 +34,9 @@ func TestREQMOD2(t *testing.T) {
 		"ICAP/1.0 200 OK\r\n" +
 			"Connection: close\r\n" +
 			"Date: Mon, 10 Jan 2000  09:55:21 GMT\r\n" +
-			"Encapsulated: req-hdr=0, req-body=231\r\n" +
 			"Istag: \"W3E4R7U9-L2E4-2\"\r\n" +
 			"Server: ICAP-Server-Software/1.0\r\n" +
+			"Encapsulated: req-hdr=0, req-body=231\r\n" +
 			"\r\n" +
 			"POST /origin-resource/form.pl HTTP/1.1\r\n" +
 			"Accept: text/html, text/plain, image/gif\r\n" +


### PR DESCRIPTION
Hello,
I've encountered some ICAP client enforcing that the `encapsulated` header is the last ICAP header.
It's just a small workaround for that case.

Thank you for the library.
